### PR TITLE
Revert "Allow custom images for compute and head node"

### DIFF
--- a/hpc-cluster-in-vnet/headnode-rdma-disabled.json
+++ b/hpc-cluster-in-vnet/headnode-rdma-disabled.json
@@ -26,18 +26,6 @@
         "description": "The VM role size"
       }
     },
-    "imgUri": {
-      "type": "string",
-      "metadata": {
-        "description": "The url of the custom head node image"
-      }
-    },
-    "imageStorageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the storage account that contains the custom images"
-      }
-    },
     "storageAccountName": {
       "type": "string",
       "metadata": {
@@ -97,14 +85,16 @@
           "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServerHPCPack",
+            "offer": "WindowsServerHPCPack",
+            "sku": "2012R2",
+            "version": "latest"
+          },
           "osDisk": {
             "name": "osdisk",
-            "osType": "Windows",
-            "image": {
-              "uri": "[parameters('imgUri')]"
-            },
             "vhd": {
-              "uri": "[concat('http://', parameters('imageStorageAccountName'),'.blob.core.windows.net/vhds/', resourceGroup().name, '-', toLower(parameters('vmName')), '-osdisk.vhd')]"
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
             },
             "caching": "ReadOnly",
             "createOption": "FromImage"
@@ -113,7 +103,7 @@
             {
               "name": "datadisk",
               "vhd": {
-                "uri": "[concat('http://',parameters('imageStorageAccountName'),'.blob.core.windows.net/vhds/', resourceGroup().name, '-', toLower(parameters('vmName')), '-datadisk.vhd')]"
+                "Uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-datadisk.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty",

--- a/hpc-cluster-in-vnet/mainTemplate.json
+++ b/hpc-cluster-in-vnet/mainTemplate.json
@@ -73,12 +73,6 @@
         "description": "The VM size for the head node"
       }
     },
-    "headNodeImageUri": {
-      "type": "string",
-      "metadata": {
-        "description": "The uri of the custom head node image"
-      }
-    },
     "headNodePrivateIP": {
       "type": "string",
       "metadata": {
@@ -95,10 +89,22 @@
         "description": "The VM image OS platform for the compute nodes"
       }
     },
-    "computeNodeImageUri": {
+    "computeNodeImagePublisher": {
       "type": "string",
       "metadata": {
-        "description": "The uri of the custom compute node image"
+        "description": "The VM image publisher for the compute nodes"
+      }
+    },
+    "computeNodeImageOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM image offer for the compute nodes"
+      }
+    },
+    "computeNodeImageSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM image sku for the compute nodes"
       }
     },
     "computeNodeNamePrefix": {
@@ -200,7 +206,7 @@
     "scriptStorageAccountName": {
       "type": "string",
       "metadata": {
-        "description": "Storage account for scripts"
+        "description": "Storage account for scripts",
       }
     },
     "scriptStorageAccountKey": {
@@ -269,7 +275,7 @@
     },
     "curCNOSPlatformRelated": "[variables('cnOsPlatformRelated')[parameters('computeNodeImageOsPlatform')]]",
     "computeNodeTemplateUrl": "[concat(parameters('artifactsBaseUrl'), '/', variables('curCNOSPlatformRelated').template)]",
-    "computeNodeCustomData": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=Custom', '\r\nVMSize=', parameters('computeNodeVMSize')))]",
+    "computeNodeCustomData": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=', parameters('computeNodeImageOffer'), '-', parameters('computeNodeImageSku'), '\r\nVMSize=', parameters('computeNodeVMSize')))]",
     "adminBase64Password": "[base64(parameters('adminPassword'))]",
     "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', parameters('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', parameters('location'), '\"')]",
     "headNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareHN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\" -CNSize ', parameters('computeNodeVMSize'), ' -PostConfigScript \"', base64(trim(parameters('headNodePostConfigScript'))), '\" ', variables('iaasInfoArg'))]",
@@ -504,12 +510,6 @@
           "vmSize": {
             "value": "[parameters('headNodeVMSize')]"
           },
-          "imgUri": {
-            "value": "[parameters('headNodeImageUri')]"
-          },
-          "imageStorageAccountName": {
-            "value": "[parameters('scriptStorageAccountName')]"
-          },
           "storageAccountName": {
             "value": "[variables('hnStorageAccountName')]"
           },
@@ -616,8 +616,17 @@
           "storageAccountName": {
             "value": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(add(div(copyIndex(), parameters('nbrCNPerStorageAccount')), variables('cnStorageAccountStartIndex'))), variables('storageAccountIndexWidth'), '0'))]"
           },
-          "imgUri": {
-            "value": "[parameters('computeNodeImageUri')]"
+          "imgPublisher": {
+            "value": "[parameters('computeNodeImagePublisher')]"
+          },
+          "imgOffer": {
+            "value": "[parameters('computeNodeImageOffer')]"
+          },
+          "imgSku": {
+            "value": "[parameters('computeNodeImageSku')]"
+          },
+          "imgVersion": {
+            "value": "latest"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -647,10 +656,10 @@
             "value": "[variables('loadBalancerName')]"
           },
           "sshPort": {
-            "value": "[copyIndex(variables('baseSSHPort'))]"
+            "value": "[copyIndex(variables('baseSSHPort'))]",
           },
           "rdpPort": {
-            "value": "[copyIndex(variables('baseRDPPort'))]"
+            "value": "[copyIndex(variables('baseRDPPort'))]",
           },
           "scriptStorageAccountName": {
             "value": "[parameters('scriptStorageAccountName')]"

--- a/hpc-cluster-in-vnet/windowsnode-rdma-disabled.json
+++ b/hpc-cluster-in-vnet/windowsnode-rdma-disabled.json
@@ -44,10 +44,28 @@
         "description": "The storage account name to store the VHD of the VM"
       }
     },
-    "imgUri": {
+    "imgPublisher": {
       "type": "string",
       "metadata": {
-        "description": "The uri of the custom compute image"
+        "description": "The publisher of the VM image"
+      }
+    },
+    "imgOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The offer of the VM image"
+      }
+    },
+    "imgSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The sku of the VM image"
+      }
+    },
+    "imgVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The version of the VM image"
       }
     },
     "adminUsername": {
@@ -120,7 +138,7 @@
     "scriptStorageAccountName": {
       "type": "string",
       "metadata": {
-        "description": "Storage account for scripts"
+        "description": "Storage account for scripts",
       }
     },
     "scriptStorageAccountKey": {
@@ -143,11 +161,11 @@
     }
   },
   "variables":{
-    "osDiskUri": "[concat('http://',parameters('scriptStorageAccountName'),'.blob.core.windows.net/vhds/', resourceGroup().name, '-', toLower(parameters('vmName')), '-os', uniqueString(parameters('subnetId')), '.vhd')]",
+    "osDiskUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-os', uniqueString(parameters('subnetId')), '.vhd')]",
     "sshNatName": "[concat(parameters('loadBalancerName'), '/', parameters('vmName'), 'SSH-VM')]",
     "rdpNatName": "[concat(parameters('loadBalancerName'), '/', parameters('vmName'), 'RDP-VM')]",
     "lbID": "[resourceId('Microsoft.Network/loadBalancers', parameters('loadBalancerName'))]",
-    "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]"
+    "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]",
   },
   "resources": [
     {
@@ -220,12 +238,14 @@
           "customData": "[parameters('customData')]"
         },
         "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imgPublisher')]",
+            "offer": "[parameters('imgOffer')]",
+            "sku": "[parameters('imgSku')]",
+            "version": "[parameters('imgVersion')]"
+          },
           "osDisk": {
             "name": "osdisk",
-            "osType": "Windows",
-            "image": {
-              "uri": "[parameters('imgUri')]"
-            },
             "vhd": {
               "uri": "[variables('osDiskUri')]"
             },


### PR DESCRIPTION
This reverts commit f3ac267335b701745aa5bdd42f22bbfb163c52eb.

The vanilla image contains .NET 4.6 now
